### PR TITLE
Feature(v1)：jsonToStruct supports interface type assignment

### DIFF
--- a/jsonUtil/json_to_struct.go
+++ b/jsonUtil/json_to_struct.go
@@ -99,6 +99,12 @@ func JsonToStruct(jsonData string, result interface{}) error {
 			} else {
 				return fmt.Errorf("unexpected value type for slice: %T", value)
 			}
+		case reflect.Interface:
+			if value == nil {
+				fieldValue.Set(reflect.Zero(fieldType.Type))
+			} else {
+				fieldValue.Set(reflect.ValueOf(value))
+			}
 		}
 	}
 	return nil

--- a/jsonUtil/json_to_struct_test.go
+++ b/jsonUtil/json_to_struct_test.go
@@ -426,9 +426,116 @@ func TestJsonToStructMoreNest2(t *testing.T) {
 			},
 		},
 	}
-	
+
 	if !reflect.DeepEqual(res, expected) {
 		t.Errorf("Result not as expected.\nExpected: %+v\nActual: %+v\n", expected, res)
+	}
+}
+
+// 普通数据类型定义 interface
+func TestJsonToStructAny1(t *testing.T) {
+	jsonData := `{
+		"name": "make",
+		"age": "10"
+	}`
+	type Target struct {
+		Name interface{} `json:"name"`
+		Age  uint        `json:"age"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
+	}
+}
+
+// 普通数据类型定义 any
+func TestJsonToStructAny2(t *testing.T) {
+	jsonData := `{
+		"name": "make",
+		"age": "10"
+	}`
+	type Target struct {
+		Name any  `json:"name"`
+		Age  uint `json:"age"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
+	}
+}
+
+// slice 中包含 interface
+func TestJsonToStructAny3(t *testing.T) {
+	jsonData := `{
+		"name": ["make",6,"tom"]
+	}`
+	type Target struct {
+		Name []interface{} `json:"name"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
+	}
+}
+
+// slice 中包含 any
+func TestJsonToStructAny4(t *testing.T) {
+	jsonData := `{
+		"name": ["make",6,"tom"]
+	}`
+	type Target struct {
+		Name []any `json:"name"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
+	}
+	fmt.Println(target, err)
+}
+
+// map 中包含 interface
+func TestJsonToStructAny5(t *testing.T) {
+	jsonData := `{
+		"name": {
+			"key1": "mike",
+			"key2": 666
+		}
+	}`
+	type Target struct {
+		Name map[string]interface{} `json:"name"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
+	}
+}
+
+// map 中包含 any
+func TestJsonToStructAny6(t *testing.T) {
+	jsonData := `{
+		"name": {
+			"key1": "mike",
+			"key2": 666
+		}
+	}`
+	type Target struct {
+		Name map[string]any `json:"name"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
 	}
 }
 

--- a/jsonUtil/parse_primitive_value.go
+++ b/jsonUtil/parse_primitive_value.go
@@ -35,11 +35,7 @@ func parsePrimitiveValue(fieldVal reflect.Value, v interface{}) error {
 		}
 		fieldVal.SetFloat(n)
 	case reflect.Bool:
-		b, ok := v.(bool)
-		if !ok {
-			return errors.New("failed to parse bool")
-		}
-		fieldVal.SetBool(b)
+		fieldVal.SetBool(toBoolReflect(v))
 	default:
 		return fmt.Errorf("unsupported kind: %s", fieldVal.Kind())
 	}

--- a/jsonUtil/parse_primitive_value.go
+++ b/jsonUtil/parse_primitive_value.go
@@ -1,7 +1,6 @@
 package jsonUtil
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 )
@@ -11,11 +10,7 @@ import (
 func parsePrimitiveValue(fieldVal reflect.Value, v interface{}) error {
 	switch fieldVal.Kind() {
 	case reflect.String:
-		str, ok := v.(string)
-		if !ok {
-			return errors.New("failed to parse string")
-		}
-		fieldVal.SetString(str)
+		fieldVal.SetString(toStringReflect(v))
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		n, err := toInt64Reflect(v)
 		if err != nil {

--- a/jsonUtil/parse_primitive_value_test.go
+++ b/jsonUtil/parse_primitive_value_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParsePrimitiveValue(t *testing.T) {
-	// Test cases for reflect.String
+	// 测试 reflect.String 类型的情况
 	strFieldVal := reflect.ValueOf(new(string)).Elem()
 	err := parsePrimitiveValue(strFieldVal, "hello")
 	if err != nil {
@@ -16,11 +16,10 @@ func TestParsePrimitiveValue(t *testing.T) {
 		t.Errorf("Expected %q, got %q", "hello", strFieldVal.String())
 	}
 	err = parsePrimitiveValue(strFieldVal, 123)
-	if err == nil {
+	if err != nil {
 		t.Error("Expected error for parsing int value as string")
 	}
-
-	// Test cases for reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64
+	// 测试 reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64 类型的情况
 	intFieldVal := reflect.ValueOf(new(int64)).Elem()
 	err = parsePrimitiveValue(intFieldVal, "123")
 	if err != nil {
@@ -34,7 +33,7 @@ func TestParsePrimitiveValue(t *testing.T) {
 		t.Error("Expected error for parsing non-int value as int")
 	}
 
-	// Test cases for reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64
+	// 测试 reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64 类型的情况
 	uintFieldVal := reflect.ValueOf(new(uint64)).Elem()
 	err = parsePrimitiveValue(uintFieldVal, "123")
 	if err != nil {
@@ -45,10 +44,10 @@ func TestParsePrimitiveValue(t *testing.T) {
 	}
 	err = parsePrimitiveValue(uintFieldVal, 123)
 	if err != nil {
-		t.Errorf("Expected error  uint, err:%v", err)
+		t.Errorf("Expected error: %v", err)
 	}
 
-	// Test cases for reflect.Float32, reflect.Float64
+	// 测试 reflect.Float32, reflect.Float64 类型的情况
 	floatFieldVal := reflect.ValueOf(new(float64)).Elem()
 	err = parsePrimitiveValue(floatFieldVal, "3.14")
 	if err != nil {
@@ -62,7 +61,7 @@ func TestParsePrimitiveValue(t *testing.T) {
 		t.Error("Expected error for parsing non-float value as float")
 	}
 
-	// Test cases for reflect.Bool
+	// 测试 reflect.Bool 类型的情况
 	boolFieldVal := reflect.ValueOf(new(bool)).Elem()
 	err = parsePrimitiveValue(boolFieldVal, true)
 	if err != nil {
@@ -72,11 +71,11 @@ func TestParsePrimitiveValue(t *testing.T) {
 		t.Errorf("Expected %t, got %t", true, boolFieldVal.Bool())
 	}
 	err = parsePrimitiveValue(boolFieldVal, "abc")
-	if err == nil {
+	if err != nil {
 		t.Error("Expected error for parsing non-bool value as bool")
 	}
 
-	// Test cases for unsupported kind
+	// 测试不支持的类型的情况
 	unsupportedFieldVal := reflect.ValueOf(new([]string)).Elem()
 	err = parsePrimitiveValue(unsupportedFieldVal, "abc")
 	if err == nil {

--- a/jsonUtil/parse_slice.go
+++ b/jsonUtil/parse_slice.go
@@ -36,6 +36,12 @@ func parseSlice(fieldValue reflect.Value, subData []interface{}) error {
 			if err != nil {
 				return err
 			}
+		} else if elemType.Kind() == reflect.Interface {
+			if item == nil {
+				elem.Set(reflect.Zero(elemType))
+			} else {
+				elem.Set(reflect.ValueOf(item))
+			}
 		} else {
 			// 否则，将项目转换为适当的类型并设置元素值
 			switch elem.Kind() {


### PR DESCRIPTION
- `JsonToStruct` 支持基本数据类型中定义 `interface{}`
- `JsonToStruct` 支持基本数据类型中定义 `any`
- 对于 `parsePrimitiveValue` 的 `string` 类型转义兼容
- 对于 `parsePrimitiveValue` 的 `bool` 类型转义兼容

close #38