### PR TITLE
Feature(v2)：jsonToStruct supports interface type assignment

### DIFF
--- a/jsonUtil/json_to_struct.go
+++ b/jsonUtil/json_to_struct.go
@@ -99,6 +99,12 @@ func JsonToStruct(jsonData string, result any) error {
 			} else {
 				return fmt.Errorf("unexpected value type for slice: %T", value)
 			}
+		case reflect.Interface:
+			if value == nil {
+				fieldValue.Set(reflect.Zero(fieldType.Type))
+			} else {
+				fieldValue.Set(reflect.ValueOf(value))
+			}
 		}
 	}
 	return nil

--- a/jsonUtil/json_to_struct_test.go
+++ b/jsonUtil/json_to_struct_test.go
@@ -418,6 +418,113 @@ func TestJsonToStructMoreNest2(t *testing.T) {
 	}
 }
 
+// 普通数据类型定义 interface
+func TestJsonToStructAny1(t *testing.T) {
+	jsonData := `{
+		"name": "make",
+		"age": "10"
+	}`
+	type Target struct {
+		Name interface{} `json:"name"`
+		Age  uint        `json:"age"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
+	}
+}
+
+// 普通数据类型定义 any
+func TestJsonToStructAny2(t *testing.T) {
+	jsonData := `{
+		"name": "make",
+		"age": "10"
+	}`
+	type Target struct {
+		Name any  `json:"name"`
+		Age  uint `json:"age"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
+	}
+}
+
+// slice 中包含 interface
+func TestJsonToStructAny3(t *testing.T) {
+	jsonData := `{
+		"name": ["make",6,"tom"]
+	}`
+	type Target struct {
+		Name []interface{} `json:"name"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
+	}
+}
+
+// slice 中包含 any
+func TestJsonToStructAny4(t *testing.T) {
+	jsonData := `{
+		"name": ["make",6,"tom"]
+	}`
+	type Target struct {
+		Name []any `json:"name"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
+	}
+	fmt.Println(target, err)
+}
+
+// map 中包含 interface
+func TestJsonToStructAny5(t *testing.T) {
+	jsonData := `{
+		"name": {
+			"key1": "mike",
+			"key2": 666
+		}
+	}`
+	type Target struct {
+		Name map[string]interface{} `json:"name"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
+	}
+}
+
+// map 中包含 any
+func TestJsonToStructAny6(t *testing.T) {
+	jsonData := `{
+		"name": {
+			"key1": "mike",
+			"key2": 666
+		}
+	}`
+	type Target struct {
+		Name map[string]any `json:"name"`
+	}
+	var target Target
+	err := JsonToStruct(jsonData, &target)
+	if err != nil {
+		t.Errorf("err %s", err)
+		return
+	}
+}
+
 // 多层级json测试
 //func TestJsonToStruct4(t *testing.T) {
 //	type Address struct {

--- a/jsonUtil/parse_map.go
+++ b/jsonUtil/parse_map.go
@@ -1,7 +1,6 @@
 package jsonUtil
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 )
@@ -40,32 +39,12 @@ func parseMap(value reflect.Value, data map[string]any) error {
 
 func parseValue(fieldVal reflect.Value, item any) error {
 	switch fieldVal.Kind() {
-	case reflect.String:
-		str, ok := item.(string)
-		if !ok {
-			return errors.New("failed to parse string")
-		}
-		fieldVal.SetString(str)
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		n, err := toInt64Reflect(item)
-		if err != nil {
+	case reflect.String, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64, reflect.Bool:
+		if err := parsePrimitiveValue(fieldVal, item); err != nil {
 			return err
 		}
-		fieldVal.SetInt(n)
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		n, err := toUint64Reflect(item)
-		if err != nil {
-			return err
-		}
-		fieldVal.SetUint(uint64(n))
-	case reflect.Float32, reflect.Float64:
-		n, err := toFloat64Reflect(item)
-		if err != nil {
-			return err
-		}
-		fieldVal.SetFloat(n)
-	case reflect.Bool:
-		fieldVal.SetBool(toBoolReflect(item))
 	case reflect.Struct:
 		if subData, ok := item.(map[string]any); ok {
 			if err := JsonToStruct(convertToJSONString(subData), fieldVal.Addr().Interface()); err != nil {

--- a/jsonUtil/parse_primitive_value.go
+++ b/jsonUtil/parse_primitive_value.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 )
 
+// 原始数据类型转换支持
+// 将数据转为Struct指定的类型
 func parsePrimitiveValue(fieldVal reflect.Value, v any) error {
 	switch fieldVal.Kind() {
 	case reflect.String:

--- a/jsonUtil/parse_primitive_value.go
+++ b/jsonUtil/parse_primitive_value.go
@@ -1,7 +1,6 @@
 package jsonUtil
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 )
@@ -9,11 +8,7 @@ import (
 func parsePrimitiveValue(fieldVal reflect.Value, v any) error {
 	switch fieldVal.Kind() {
 	case reflect.String:
-		str, ok := v.(string)
-		if !ok {
-			return errors.New("failed to parse string")
-		}
-		fieldVal.SetString(str)
+		fieldVal.SetString(toStringReflect(v))
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		n, err := toInt64Reflect(v)
 		if err != nil {
@@ -33,20 +28,9 @@ func parsePrimitiveValue(fieldVal reflect.Value, v any) error {
 		}
 		fieldVal.SetFloat(n)
 	case reflect.Bool:
-		b, ok := v.(bool)
-		if !ok {
-			return errors.New("failed to parse bool")
-		}
-		fieldVal.SetBool(b)
+		fieldVal.SetBool(toBoolReflect(v))
 	default:
 		return fmt.Errorf("unsupported kind: %s", fieldVal.Kind())
 	}
 	return nil
 }
-
-//case reflect.String, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-//reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-//reflect.Float32, reflect.Float64, reflect.Bool:
-//if err := parsePrimitiveValue(fieldVal, v); err != nil {
-//return err
-//}

--- a/jsonUtil/parse_primitive_value_test.go
+++ b/jsonUtil/parse_primitive_value_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParsePrimitiveValue(t *testing.T) {
-	// Test cases for reflect.String
+	// 测试 reflect.String 类型的情况
 	strFieldVal := reflect.ValueOf(new(string)).Elem()
 	err := parsePrimitiveValue(strFieldVal, "hello")
 	if err != nil {
@@ -16,11 +16,10 @@ func TestParsePrimitiveValue(t *testing.T) {
 		t.Errorf("Expected %q, got %q", "hello", strFieldVal.String())
 	}
 	err = parsePrimitiveValue(strFieldVal, 123)
-	if err == nil {
+	if err != nil {
 		t.Error("Expected error for parsing int value as string")
 	}
-
-	// Test cases for reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64
+	// 测试 reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64 类型的情况
 	intFieldVal := reflect.ValueOf(new(int64)).Elem()
 	err = parsePrimitiveValue(intFieldVal, "123")
 	if err != nil {
@@ -34,7 +33,7 @@ func TestParsePrimitiveValue(t *testing.T) {
 		t.Error("Expected error for parsing non-int value as int")
 	}
 
-	// Test cases for reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64
+	// 测试 reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64 类型的情况
 	uintFieldVal := reflect.ValueOf(new(uint64)).Elem()
 	err = parsePrimitiveValue(uintFieldVal, "123")
 	if err != nil {
@@ -45,10 +44,10 @@ func TestParsePrimitiveValue(t *testing.T) {
 	}
 	err = parsePrimitiveValue(uintFieldVal, 123)
 	if err != nil {
-		t.Errorf("Expected error  uint, err:%v", err)
+		t.Errorf("Expected error: %v", err)
 	}
 
-	// Test cases for reflect.Float32, reflect.Float64
+	// 测试 reflect.Float32, reflect.Float64 类型的情况
 	floatFieldVal := reflect.ValueOf(new(float64)).Elem()
 	err = parsePrimitiveValue(floatFieldVal, "3.14")
 	if err != nil {
@@ -62,7 +61,7 @@ func TestParsePrimitiveValue(t *testing.T) {
 		t.Error("Expected error for parsing non-float value as float")
 	}
 
-	// Test cases for reflect.Bool
+	// 测试 reflect.Bool 类型的情况
 	boolFieldVal := reflect.ValueOf(new(bool)).Elem()
 	err = parsePrimitiveValue(boolFieldVal, true)
 	if err != nil {
@@ -72,11 +71,11 @@ func TestParsePrimitiveValue(t *testing.T) {
 		t.Errorf("Expected %t, got %t", true, boolFieldVal.Bool())
 	}
 	err = parsePrimitiveValue(boolFieldVal, "abc")
-	if err == nil {
+	if err != nil {
 		t.Error("Expected error for parsing non-bool value as bool")
 	}
 
-	// Test cases for unsupported kind
+	// 测试不支持的类型的情况
 	unsupportedFieldVal := reflect.ValueOf(new([]string)).Elem()
 	err = parsePrimitiveValue(unsupportedFieldVal, "abc")
 	if err == nil {

--- a/jsonUtil/parse_slice.go
+++ b/jsonUtil/parse_slice.go
@@ -36,6 +36,12 @@ func parseSlice(fieldValue reflect.Value, subData []any) error {
 			if err != nil {
 				return err
 			}
+		} else if elemType.Kind() == reflect.Interface {
+			if item == nil {
+				elem.Set(reflect.Zero(elemType))
+			} else {
+				elem.Set(reflect.ValueOf(item))
+			}
 		} else {
 			// 否则，将项目转换为适当的类型并设置元素值
 			switch elem.Kind() {


### PR DESCRIPTION
- `JsonToStruct` 支持基本数据类型中定义 `interface{}`
- `JsonToStruct` 支持基本数据类型中定义 `any`
- 对于 `parsePrimitiveValue` 的 `string` 类型转义兼容
- 对于 `parsePrimitiveValue` 的 `bool` 类型转义兼容

close #38